### PR TITLE
지역 스키마에 행정동 및 도시 코드 추가하기

### DIFF
--- a/src/place.d.ts
+++ b/src/place.d.ts
@@ -4,6 +4,8 @@ interface Place {
 		description: string;
 		keywords: string[];
 		hints: string[];
+    EMD_CD: string; // 행정동 코드
+	  COL_ADM_SE: string; // 도시 코드
 	};
 	result: {
 		placeName: string;


### PR DESCRIPTION
해당 지명 코드는 https://www.vworld.kr/dtmk/dtmk_ntads_s002.do?dsId=30603 제주 지역 데이터를 출처로 참조합니다.